### PR TITLE
add search scope

### DIFF
--- a/globalization/docfx.json
+++ b/globalization/docfx.json
@@ -37,7 +37,8 @@
             "ms.service": "globalization",
             "ms.topic": "conceptual",
             "ms.date": "08/08/2017",
-            "ms.author": "khairunj"
+            "ms.author": "khairunj",
+            "searchScope": ["Globalization"]
         },
         "fileMetadata": {},
         "template": [],


### PR DESCRIPTION
I've noticed that the Globalization docs didn't have a search scope defined. That allows customers to just search for content inside this docset, instead of the entire docs.microsoft.com site.

You can see that in other content sets such as .NET:
https://docs.microsoft.com/en-us/dotnet/welcome

![image](https://user-images.githubusercontent.com/12971179/39455530-c4eaf8e0-4c95-11e8-9ee4-4b9bafb581d7.png)
