### PR TITLE
Fix incorrect links, add links and descriptions to Input page

### DIFF
--- a/globalization/input/input.md
+++ b/globalization/input/input.md
@@ -3,7 +3,28 @@
 # Input, Output, and Display
 
 [Text Input, Output, and Display](text-input.md)  
-The input, output, and display of data can be complicated when the users needs to enter/receive data in different languages.
+The input, output, and display of data can be complicated when the user needs to enter/receive data in different languages.
+
+[Text Rendering](text-rendering.md)  
+Text rendering is the process of converting a string to a format that is readable to the user. 
+
+[Page or Text Alignment](page-or-text-alignment.md)
+The alignment, justification, and direction of text relative to a page, column, table, cell, or tab.
+
+[Text Justification](text-justification.md)
+Rules relating to margins for different scripts or cultures. 
+
+[Font Technology](font-technology.md)
+Understanding different types of fonts, formats, and operating-system level tools such as font fallback and font linking.
+
+[Line and Word Breaking](line-and-word-breaking.md)  
+The word and line breaking add a special case when multilingual text is to be parsed or displayed.
+
+[Mirroring](mirroring.md)  
+UI elements should follow the natural left-to-right or right-to-left reading order of the language.
+
+[Overlay Text Properties](overlay.md)  
+Properties--such as phonetic guides, emphasis, and enclosures--not just of individual glyphs but entire strings.
 
 [Capitalization, Uppercasing, and Lowercasing](https://msdn.microsoft.com/library/mt662330)  
 When creating a locale–aware application, you'll need to consider handling of linguistic nuances. These nuances might seem trivial, but could have a large impact on application design and functionality.
@@ -11,10 +32,5 @@ When creating a locale–aware application, you'll need to consider handling of 
 [Fonts](https://msdn.microsoft.com/library/mt662331)  
 One of the biggest challenges in enabling the operating system for international character sets is the ability to select and display the right character or glyph.
 
-[Line and Word Breaking](line-and-word-breaking.md)  
-The word and line breaking add a special case when multilingual text is to be parsed or displayed.
-
 [Complex Scripts Awareness](https://msdn.microsoft.com/library/mt662335)  
 All language versions of Windows are enabled for all supported languages, thereby empowering applications that use Unicode as their encoding model to handle mixed text from any of the supported scripts.
-
-

--- a/globalization/toc.yml
+++ b/globalization/toc.yml
@@ -65,7 +65,7 @@
       - name: Units of Measurement
         href: locale/units-of-measurement.md
     - name: Input, Output, and Display
-      href: input/text-input.md
+      href: input/input.md
       items:
       - name: Text Input, Output, and Display
         href: input/text-input.md


### PR DESCRIPTION
Per issue #53, I made the following changes:
- Corrected top-level ("Input, Output, and Display") link in TOC changing destination from "input/text-input" to "input/input"
- Added links and descriptions to **/input/input** page for items in TOC 
-- Text Rendering
-- Page or text Alignment
-- Text Justification
-- Font Technology
-- Moved "Line and Word Breaking" to this spot
-- Mirroring
-- Overlay Text Properties
- Moved "Capitalization, Uppercasing, and Lowercasing" and "Fonts" to the bottom with "Complex Scripts Awareness" so all external links (also these are not in TOC) are together.