### PR TITLE
fix language ids

### DIFF
--- a/globalization/input/console-globalization.md
+++ b/globalization/input/console-globalization.md
@@ -22,7 +22,7 @@ CRT locale support is built around the *(\_w)setlocale(category, locale)* call, 
 
 In order to set the rules for formatting locale-sensitive data in accordance with the user locale, the following calls can be executed:
 
-```C++
+```cpp
 _wsetlocale (LC_COLLATE, L(".OCP") );  // sets the sort order`
 _wsetlocale (LC_MONETARY, L(".OCP") ); // sets the currency formatting rules`
 _wsetlocale (LC_NUMERIC, L(".OCP") );  // sets the formatting of numerals`

--- a/globalization/input/text-rendering.md
+++ b/globalization/input/text-rendering.md
@@ -18,7 +18,7 @@ When creating a locale-aware application, you'll need to consider handling of li
 
 In the past, as localized products were developed, language-sensitive issues—such as casing—were sometimes handled with what were thought of as well-designed, intelligent algorithms. For example, an uppercasing macro that relies on the code–point numbers of ASCII characters and the linear relationship between uppercase characters (A = 41) and lowercase characters (a = 61) can be written as:
 
-```C++
+```cpp
 #define ToUpper(ch) ((ch)&lt;='Z' ? (ch) : (ch)+'A' - 'a')
 ```
 

--- a/globalization/locale/currency-formatting-in-the-dotnet-framework.md
+++ b/globalization/locale/currency-formatting-in-the-dotnet-framework.md
@@ -12,7 +12,7 @@ The .NET format strings are useful if you want to convert one of the standard .N
 
 In the following code example, the ToString method displays the value of 100 as a currency-formatted string in the console's output window.
 
-```C#
+```csharp
 int MyInt = 100;
 String MyString = MyInt.ToString("C");
 Console.WriteLine(MyString);
@@ -24,7 +24,7 @@ The CurrencySymbol property of the RegionInfo class from the System.Globalizatio
 
 The following example uses code that is similar to the previous example. It sets the current culture to "fr-FR" and displays an integer to the console formatted as currency. The user's local currency settings are used to format the currency. Next, the culture is set to "fr-FR" using the CultureInfo constructor that accepts the useUserOverride parameter set to false. The number is then formatted using the .NET Framework default settings, and the euro currency symbol is displayed.
 
-```C#
+```csharp
 using System;
 using System.Globalization;
 using System.Threading;
@@ -60,7 +60,7 @@ If you execute this code in a Windows Forms application, the output appears as f
 
 Although most European Union countries now use the euro, there might be situations-such as for legacy reasons-where it is necessary to display both the euro and the older currencies in an application. The following code example creates a CultureInfo object for the culture "fr-FR" where the default currency is the euro. To display the currency symbol for the local currency, you must use the NumberFormatInfo.Clone method to clone a new NumberFormatInfo object for the CultureInfo object and replace the default currency symbol with a local currency symbol.
 
-```C#
+```csharp
 using System;
 using System.Globalization;
 using System.Threading;

--- a/globalization/locale/currency-formatting-in-win32.md
+++ b/globalization/locale/currency-formatting-in-win32.md
@@ -10,7 +10,7 @@ ms.date: 03/16/2016
 
 Win32 NLS APIs can help you display currency data in a way that's locale-aware. The GetCurrencyFormat function formats a number string as a currency string for a specified locale. The code sample on the following page formats a number string into the user locale's default format:
 
-```C++
+```cpp
 GetCurrencyFormat(LOCALE\_USER\_DEFAULT, // a predefined value for user locale
       NULL, // operation option
       TEXT("123.40"), // input number (see MSDN for accepted chars)
@@ -29,7 +29,7 @@ With this approach, the number string is formatted to a locale-specific format a
 
 Another scenario would be the use of the euro. The .NET Framework and Windows set the default currency symbol to the euro for members of the eurozone. However, older versions of Windows, without any intervention, will still set the default currency symbol to the local currency for these countries or regions. To resolve the issue in the two scenarios just mentioned, you can take advantage of the lpFormat argument of GetCurrencyFormat. This argument is a pointer to a currency-formatting structure, where you can define your own formatting model and specify the currency symbol to be used following the formatting standard of a given locale. The following code sample uses the formatting for the currently selected user locale, but with the euro as the desired currency symbol. Here is how it works.
 
-```C++
+```cpp
 CURRENCYFMT CurFormat;
 // first fill in the currencyfmt structure with user locale-specific information.
 getlocaleinfo(locale\_user\_default, locale\_return\_number|locale\_idigits, &curformat.numdigits, str\_len):;

--- a/globalization/locale/handling-calendars-in-dotnet-framework.md
+++ b/globalization/locale/handling-calendars-in-dotnet-framework.md
@@ -5,10 +5,9 @@ ms.assetid: 52135192-e034-47d3-8c22-4f988b8ffdc8
 ms.date: 03/16/2016
 ---
 
-
 # Handling Calendars in .NET Framework
 
-Similar to the Win32 paradigm - the .NET Framework handles dates in the Gregorian calendar by using data structures. Therefore, when you use the methods provided by the [DateTime](http://msdn2.microsoft.com/en-us/library/system.datetime.aspx) structure, you must be aware that the members such as the DateTime.Day property, the DateTime.Month property, the DateTime.Year property, and the DateTime.AddDays method are based on the Gregorian calendar. Even if you change the current calendar in your application's code or change date and time settings through the Regional And Language Options property sheet, the Gregorian calendar is still used to perform the calculations for these methods. This functionality prevents the arithmetic performed by these methods from being corrupted by a user's settings. If you want to perform culture-sensitive date and time operations based on the current calendar, you must use the [DateTimeFormatInfo.Calendar](http://msdn2.microsoft.com/en-us/library/system.globalization.datetimeformatinfo.calendar.aspx) property to call methods provided by the [Calendar](http://msdn2.microsoft.com/en-us/library/system.web.ui.webcontrols.calendar.aspx) class such as *Calendar.GetDayOfMonth*, *Calendar.GetMonth*, *Calendar.GetYear*, and *Calendar.AddDays*.
+Similar to the Win32 paradigm - the .NET Framework handles dates in the Gregorian calendar by using data structures. Therefore, when you use the methods provided by the [DateTime](https://docs.microsoft.com/dotnet/api/system.datetime) structure, you must be aware that the members such as the DateTime.Day property, the DateTime.Month property, the DateTime.Year property, and the DateTime.AddDays method are based on the Gregorian calendar. Even if you change the current calendar in your application's code or change date and time settings through the Regional And Language Options property sheet, the Gregorian calendar is still used to perform the calculations for these methods. This functionality prevents the arithmetic performed by these methods from being corrupted by a user's settings. If you want to perform culture-sensitive date and time operations based on the current calendar, you must use the [DateTimeFormatInfo.Calendar](https://docs.microsoft.com/dotnet/api/system.globalization.datetimeformatinfo.calendar) property to call methods provided by the [Calendar](https://docs.microsoft.com/dotnet/api/system.web.ui.webcontrols.calendar) class such as *Calendar.GetDayOfMonth*, *Calendar.GetMonth*, *Calendar.GetYear*, and *Calendar.AddDays*.
 
 To handle native calendar types, the .NET Framework provides the Calendar class as well as the following Calendar implementations: GregorianCalendar, HebrewCalendar, HijriCalendar, JapaneseCalendar, JulianCalendar, KoreanCalendar, TaiwanCalendar, and ThaiBuddhistCalendar. Other things you can use include the CultureInfo class, which has a CultureInfo.Calendar property that specifies a culture's default calendar. The CultureInfo.OptionalCalendars property specifies the optional calendars supported by a culture.
 
@@ -66,7 +65,7 @@ public class TestClass
 }
 ```
 
-This code produces the following output: 
+This code produces the following output:
 
 ```The default calendar for the Thai (Thailand) culture is:
 System.Globalization.ThaiBuddhistCalendar
@@ -76,6 +75,5 @@ System.Globalization.ThaiBuddhistCalendar
 System.Globalization.GregorianCalendar
 subtype Localized
 ```
-As you can see, the .NET Framework offers a UI that's extensive, yet flexible and easy to use for date and calendar formatting. 
 
-
+As you can see, the .NET Framework offers a UI that's extensive, yet flexible and easy to use for date and calendar formatting.

--- a/globalization/locale/handling-calendars-in-dotnet-framework.md
+++ b/globalization/locale/handling-calendars-in-dotnet-framework.md
@@ -14,7 +14,7 @@ To handle native calendar types, the .NET Framework provides the Calendar class 
 
 The following code example in C\# creates CultureInfo objects for the culture "th-TH" (Thai in Thailand) and displays the default and optional calendars for each culture. The GregorianCalendar is further divided into subtypes by the GregorianCalendar.CalendarType property. In this example, each time the calendar is determined to be Gregorian, the CalendarType value is retrieved and displayed.
 
-```C#
+```csharp
 using System;
 using System.Globalization;
 public class TestClass

--- a/globalization/locale/handling-calendars-in-win32.md
+++ b/globalization/locale/handling-calendars-in-win32.md
@@ -12,11 +12,11 @@ As you probably noticed in the last code sample, one of the arguments of the enu
 
 The [EnumCalendarInfoEx](https://msdn.microsoft.com/library/dd317804.aspx) API can be used to enumerate all calendar information (such as names of calendars, names of days of the week, and names of months) for all applicable and available calendar types pertaining to a given locale. The code sample enumerates the native names of all supported calendars.
 
-```C++
+```cpp
 // Enumerate the native calendar names for all available calendar
 // types that correspond to the current user locale.
 EnumCalendarInfoEx(EnumCalendarInfoProc,   // enumeration callback
-// fuction
+// function
 LOCALE\_USER\_DEFAULT,   // locale - any valid LCID
 ENUM\_ALL\_CALENDARS,    // does enumeration for all supported
 
@@ -40,12 +40,10 @@ Execution of the previous code sample would give the following result on English
 
 The [GetLocaleInfo](https://msdn.microsoft.com/library/dd318101.aspx) API with the LOCALE\_ICALENDARTYPE flag also allows you to retrieve the default calendar type currently selected by the user. Once you have retrieved the calendar you want, you can use [GetCalendarInfo](https://msdn.microsoft.com/library/dd318072.aspx) to retrieve specific information about that particular calendar. This information includes the following:
 
--   Long, short, and year/month date formats
--   Abbreviations and full names of months
--   Abbreviations and full names of days of the week
--   An integer value indicating the upper boundary of the two-digit year range
--   Native name of the calendar
+- Long, short, and year/month date formats
+- Abbreviations and full names of months
+- Abbreviations and full names of days of the week
+- An integer value indicating the upper boundary of the two-digit year range
+- Native name of the calendar
 
 In a nutshell, Win32 NLS APIs give your application full control over the way a date can be represented by letting you select a given calendar type and a given formatting type for that calendar. In fact, NLS APIs give you more flexibility than you would ever need. As stated earlier, GetDateFormat is probably enough to format dates in a way that's locale-aware.
-
-

--- a/globalization/locale/number-formatting-in-dotnet-framework.md
+++ b/globalization/locale/number-formatting-in-dotnet-framework.md
@@ -25,7 +25,7 @@ The *NumberFormatInfo* class defines how currency, decimal separators, and other
 
 The following code example displays an integer using the *NumberFormatInfo* standard currency format ("c") for the specified *CurrentCulture*.
 
-```C#
+```csharp
 using System.Globalization;
 public class TestClass
 {

--- a/globalization/locale/number-formatting-in-win32.md
+++ b/globalization/locale/number-formatting-in-win32.md
@@ -11,7 +11,7 @@ author: pallep
 
 The easiest way to format numbers in a way that's locale-aware is to use the GetNumberFormat API. This API customizes the format of a number string for a specified locale. The following shows how the GetNumberFormat API is used to format a given number string for the current user locale (using the default settings for number formatting that the user has defined):
 
-```C++
+```cpp
 GetNumberFormat(LOCALE_USER_DEFAULT, // locale (current user locale)
           0,                           // options
           TEXT("1234567890.12345"),    // input string (see MSDN for legal chars)
@@ -40,7 +40,7 @@ Possible return values are shown in Table 1 below.
 
 **Native digits.** LCType flag set to LOCALE_SNATIVEDIGITS. Here is a code sample that deals with native digits:
 
-```C++
+```cpp
 GetLocaleInfo(LOCALE_USER_DEFAULT, // LCID (current user locale)
           LOCALE_SNATIVEDIGITS,     // information type (native digits)
           &g_szTemp,                // returned value
@@ -58,7 +58,7 @@ This code would produce the following result on English (US) and Persian locales
 |Value|Meaning|
 |---|---|
 |0|Content - The shape depends on the previous text in the same output.|
-|1|None/Arabic - Gives full Unicode compatability.|
+|1|None/Arabic - Gives full Unicode compatibility.|
 |2|Native - National shapes determined by LOCALE_SNATIVEDIGITS.|
 
 **Table 2:** Return values of LOCALE_IDIGITSUBSTITUTION

--- a/globalization/locale/sorting-and-string-comparison.md
+++ b/globalization/locale/sorting-and-string-comparison.md
@@ -85,7 +85,7 @@ To mitigate against this, applications can call [GetNLSVersionEx](https://msdn.m
 
 The Array class provides an overloaded method that allows you to sort arrays based on the CultureInfo.CurrentCulture property. In the following example, an array of three strings is created. First, the [CurrentCulture](https://docs.microsoft.com/dotnet/api/system.threading.thread.currentculture) is set to "en-US" and the method is called. The resulting sort order is based on sorting conventions for the "en-US" culture. Next, the [CurrentCulture](https://docs.microsoft.com/dotnet/api/system.threading.thread.currentculture) is set to "da-DK" and the method is called again. Notice how the resulting sort order differs from the "en-US" results because the sorting conventions for the "da-DK" culture are used.
 
-```C#
+```csharp
     using System;
     using System.Threading ;
     using System.Globalization ;

--- a/globalization/locale/time-formatting-and-time-zones-in-dotnet-framework.md
+++ b/globalization/locale/time-formatting-and-time-zones-in-dotnet-framework.md
@@ -14,7 +14,7 @@ Methods and properties in the *DateTime* structure always use the local time zon
 
 Use the *DateTime.ToUniversalTime* method to convert a local *DateTime* to its UTC equivalent. To parse a date/time string and convert it to a UTC DateTime, use the *DateTimeStyles* enumeration *AdjustToUniversal* value with either the *DateTime.Parse* or *DateTime.ParseExact* method. These *DateTime* manipulations are illustrated in the following code example. This example creates a *DateTime* for the local time and then converts it to the UTC equivalent *DateTime*. Both types are converted to strings and written to the console. Notice that the strings differ by the UTC offset between the local time zone and UTC. (For more information on the UTC offset for various time zones, see the [TimeZone.GetUtcOffset](/dotnet/api/system.timezone.getutcoffset) method.) These strings are converted back to *DateTime* types using the *DateTime.ParseExact* method. To capture the time-zone information stored in *utcdt*, the *AdjustToUniversal* value must be specified as a parameter to the *DateTime.ParseExact* method.
 
-```C#
+```csharp
 using System;
 using System.Globalization;
 using System.Threading;

--- a/globalization/locale/time-formatting-and-time-zones-in-win32.md
+++ b/globalization/locale/time-formatting-and-time-zones-in-win32.md
@@ -12,7 +12,7 @@ To format time in the default settings of a given locale or as specified by the 
 
 The following code sample displays the current system time for the current user locale, using the default time format for that locale: 
 
-```C++
+```cpp
 // Formats time as a time string for a specified locale.
 GetTimeFormat(LOCALE_USER_DEFAULT, // predefined current user locale
     0, // option flag for things like no usage of seconds or
@@ -32,7 +32,7 @@ Execution of this code would give the following result on English (United States
 
 As you saw in the previous example, the time formatting can be completely different from one locale to another. In this case, the use of a leading 0 in the hour representation, as well as the actual translation and positioning of P.M., change based on country and cultural standards. But even within the same locale or culture there is a variety of possible ways to format time: short or long formatting. The EnumTimeFormats function enumerates the time formats that are available for a specified locale. It does so by passing (to a callback function that an application defines) a pointer to a buffer that contains a time format. The EnumTimeFormats continues to do so until no more time formats are found, or until the callback function returns FALSE. Here is how the code works:
 
-```C++
+```cpp
 EnumTimeFormats(EnumTimeFormatsProc, // enumeration callback function
      LOCALE_USER_DEFAULT, // locale for which the enumeration is done
      NULL); // unused
@@ -87,7 +87,7 @@ use the following picture string:
 
 To retrieve information regarding the time parameters for a particular time zone that the user has selected, you can use the GetTimeZoneInformation function. These parameters control the translations between UTC and local time.
 
-```C++
+```cpp
 DWORD GetTimeZoneInformation(LPTIME_ZONE_INFORMATION lpTimeZoneInformation);
 // Where LPTIME_ZONE_INFORMATION is defined as:
 typedef struct _TIME_ZONE_INFORMATION

--- a/globalization/locale/time-formatting-and-time-zones-in-win32.md
+++ b/globalization/locale/time-formatting-and-time-zones-in-win32.md
@@ -4,13 +4,11 @@ description:
 ms.assetid: f468cc75-fdc5-4716-a42f-91df92b89401
 ms.date: 03/16/2016
 ---
-
-
 # Time Formatting and Time Zones in Win32
 
 To format time in the default settings of a given locale or as specified by the user in the **Regional and Language Options** Control Panel, you can use GetTimeFormat. This function formats time—either a specified time or the local system time—as a time string for a specified locale.
 
-The following code sample displays the current system time for the current user locale, using the default time format for that locale: 
+The following code sample displays the current system time for the current user locale, using the default time format for that locale:
 
 ```cpp
 // Formats time as a time string for a specified locale.
@@ -26,7 +24,7 @@ GetTimeFormat(LOCALE_USER_DEFAULT, // predefined current user locale
 
 Execution of this code would give the following result on English (United States) and Punjabi user locales, respectively. (See Figure 1 below)
 
-![TimeFormat-Win32](https://docs.microsoft.com/globalization/locale/images/Punjabi_Time.jpg "TimeFormat-Win32") 
+![TimeFormat-Win32](./images/Punjabi_Time.jpg "TimeFormat-Win32")
 
 **Figure 1:** Time formatted for English (United States) and Punjabi user locales
 
@@ -36,7 +34,7 @@ As you saw in the previous example, the time formatting can be completely differ
 EnumTimeFormats(EnumTimeFormatsProc, // enumeration callback function
      LOCALE_USER_DEFAULT, // locale for which the enumeration is done
      NULL); // unused
- 
+
     // The callback function...
     BOOL CALLBACK EnumTimeFormatsProc(LPTSTR lpTimeFormatString)
      {
@@ -50,7 +48,7 @@ EnumTimeFormats(EnumTimeFormatsProc, // enumeration callback function
 
 Execution of this code would give the following result on English (United States) and French (France) user locales, respectively. (See Figure 2 below.)
 
-![FrenchTimeFormat](https://docs.microsoft.com/globalization/locale/images/French_Time.jpg "FrenchTimeFormat") 
+![FrenchTimeFormat](./images/French_Time.jpg "FrenchTimeFormat")
 
 **Figure 2:** Time formats for English (United States) and French (France) user locales
 
@@ -76,13 +74,13 @@ The obtained result (format picture) can then be used as an lpFormat argument in
 For example, to get the time string:
 
 ```
-"11:29:40 PM" 
+"11:29:40 PM"
 ```
 
 use the following picture string:
 
 ```
-"hh':'mm':'ss tt" 
+"hh':'mm':'ss tt"
 ```
 
 To retrieve information regarding the time parameters for a particular time zone that the user has selected, you can use the GetTimeZoneInformation function. These parameters control the translations between UTC and local time.
@@ -99,7 +97,7 @@ typedef struct _TIME_ZONE_INFORMATION
      WCHAR DaylightName[ 32 ];
      SYSTEMTIME DaylightDate;
      LONG DaylightBias
-    } 
+    }
     TIME_ZONE_INFORMATION, *PTIME_ZONE_INFORMATION;
 ```
 
@@ -108,9 +106,7 @@ The *Bias* parameter of the TIME\_ZONE\_INFORMATION structure is the difference,
 All translations between UTC time and local time are based on the following formula:
 
 ```
-UTC = local time + bias 
+UTC = local time + bias
 ```
 
-Unfortunately, Win32 APIs do not offer a solution to enumerate information relative to any other time zone than the one currently selected by the user. GetLocalTime and GetSystemTime will allow you to retrieve the current local and the UTC times, respectively. To convert the local time to UTC, you can use the LocalFileTimeToFileTime API. These are but two of the many Win32 APIs dealing with time. To learn about other functions, search for "time functions" on [http://msdn.microsoft.com.](http://msdn2.microsoft.com/)
-
-
+Unfortunately, Win32 APIs do not offer a solution to enumerate information relative to any other time zone than the one currently selected by the user. GetLocalTime and GetSystemTime will allow you to retrieve the current local and the UTC times, respectively. To convert the local time to UTC, you can use the LocalFileTimeToFileTime API. These are but two of the many Win32 APIs dealing with time. To learn about other functions, search for "time functions" on <https://docs.microsoft.com/>.

--- a/globalization/locale/units-of-measurement.md
+++ b/globalization/locale/units-of-measurement.md
@@ -25,7 +25,7 @@ Although you need to do your own conversions between the metric and US systems, 
 
 The system of measurement can be obtain from [GetLocaleInfoEx](/windows/desktop/api/winnls/nf-winnls-getlocaleinfoex) API with [LCTYPE](/windows/desktop/Intl/locale-information-constants#constants-used-in-the-lctype-parameter-of-getlocaleinfo-getlocaleinfoex-and-setlocaleinfo) flag set to *LOCALE\_IMEASURE*. The returned value is 0 if the metric system (Système International d'unités, or S.I.) is used, and 1 if the U.S. system is used. The maximum number of characters allowed for this string is two.
 
- ```C++
+ ```cpp
 DWORD dwMSys;
 GetLocaleInfo(LOCALE\_USER\_DEFAULT,     // locale identifier (current user locale)
 LOCALE\_IMEASURE|LOCALE\_RETURN\_NUMBER, // information type (measurement system)

--- a/globalization/localizability/avoid-run-time-composite-strings.md
+++ b/globalization/localizability/avoid-run-time-composite-strings.md
@@ -12,7 +12,7 @@ When creating strings for output, well-intentioned programmers use a coding tric
 -   "Are you sure you want to delete the directory?"
 -   "Are you sure you want to delete the subdirectory?"
 
-```C++
+```cpp
 char szString[] = "Are you sure you want to delete the ";
 
 char szFinalString[cbMaxSz]= szString + szDelObject + "?";
@@ -20,7 +20,7 @@ char szFinalString[cbMaxSz]= szString + szDelObject + "?";
 
 Note that szDelObject is a variable that can contain either a file, directory, or subdirectory. This practice works well for the programmer, but all the translator sees in the resource file is "Are you sure you want to delete the "; the translator has no idea what is being deleted. The value of the variable often determines whether a different syntax or definite article needs to be used, depending on the item to be deleted. The reason is that in some languages nouns have gender. For instance, in German nouns can be masculine, feminine, or neuter. In Romance languages such as French or Portuguese, nouns are either masculine or feminine. Depending on the gender of the noun in such languages, the definite article that precedes the noun will vary. For example, French uses "le" in front of masculine nouns (such as "le fils" for "the son") and "la" in front of feminine nouns (such as "la fille" for "the daughter"). Thus for the previous code, a French translator would not know whether to use "le" or "la," because the actual value of the variable-in this case, the noun-is not specified. The best way to avoid this ambiguity is to write out each sentence completely, if possible. This way the translator knows the context of the sentence and can translate it correctly. Thus in your resource store you would have:
 
-```C++
+```cpp
 Del_File = "Are you sure you want to delete the file?";
 
 Del_Dir = "Are you sure you want to delete the directory?";
@@ -30,7 +30,7 @@ Del SubD = "Are you sure you want to delete the subdirectory?";
 
 Another potential shortcut involves declaring a single string, such as "none," "blue," or "first," and displaying it in a number of different contexts-on a menu, in a dialog box, and perhaps in several messages. The problem with using "all-purpose" strings is that in European languages, adjectives (and some nouns) have anywhere from 4 to 14 different forms (for example, masculine, feminine, and neuter singular; and masculine, feminine, and neuter plural) that must match the nouns they modify. For instance, in Spanish the word "first" can be conveyed by the words "primero," "primera," "primer," "primeros," and "primeras," depending on the gender and number of the noun or the particular sentence structure. A single string displayed in different contexts will be correct in gender and number in some cases but incorrect in others. The user will consider such a translation amateurish. Again, the way to handle this problem is to have a separate string for the same word used in a different context, such as the following strings:
 
-```C++
+```cpp
 Menu_open = "open"
         
 Dialog_open = "open"

--- a/globalization/localizability/do-not-compound-several-variables.md
+++ b/globalization/localizability/do-not-compound-several-variables.md
@@ -8,7 +8,7 @@ ms.date: 06/28/2016
 
 As stated before, there are times that variables are necessary because you might not know what needs to go in the string until run time. Things like dates, time, temperature, and number of sales are just a few examples of these types of variables. Besides giving these variables unique names, you need to make sure that you don't compound several variables together. For example, a translator ran across the following during a localization job:
 
-```C++
+```cpp
 "%d:%d%s on %s, %s %d, %d"
 ```
 

--- a/globalization/localizability/dotnet-framework-string-format.md
+++ b/globalization/localizability/dotnet-framework-string-format.md
@@ -8,19 +8,19 @@ ms.date: 06/28/2016
 
 The .NET Framework has a counterpart to Win32's FormatMessage—the String.Format method. It allows you to number your variable placeholders so that localizers can rearrange them depending on the syntax of the language into which you are translating, without having to rearrange the variables themselves in the method call. The one difference between FormatMessageand String.Format is that instead of using FormatMessage's percent sign (%) plus some number to designate the placeholder, String.Format encompasses the number within braces "{ }." So the earlier example would be changed from the FormatMessage syntax of:
 
-```C#
+```csharp
 "Not enough memory to %1 the file %2."
 ```
 
 to the String.Format syntax of:
 
-```C#
+```csharp
 "Not enough memory to {0} the file {1}."
 ```
 
 The call in your program would be:
 
-```C#
+```csharp
 String.Format("Not enough memory to {0} the file {1}", sFunc, sFile);
 ```
 
@@ -33,13 +33,13 @@ FormatString is an optional string of formatting codes.
 
 If the value of format is "[Brad's dog has {0,-8:G} fleas.]", [arg0] is a 16-bit integer with the value 42, (and in this example, underscores represent padding spaces) then the return value will be:
 
-```C#
+```csharp
 "Brad's dog has 42______ fleas."
 ```
 
 The .NET Framework has also added the idea of an argument placeholder to its Console.Write method. So an application that uses the standard input, output, and error streams for console applications can use the same syntax as the String.Format method to allow it to be more localizable, such as shown here:
 
-```C#
+```csharp
 Console.Write("Not enough memory to {0} the file {1}", sFunc, sFile);
 ```
 

--- a/globalization/localizability/element-resizing.md
+++ b/globalization/localizability/element-resizing.md
@@ -48,7 +48,7 @@ While the configuration of Windows where your application runs might not provide
 
 Controls, such as radio buttons and check boxes that allow the text to wrap are another way of handling text expansion. To allow multiple lines in a Win32 resource file, you can either manually add the BS\_MULTILINE property to the control (shown within bold in the following code):
 
-```C++
+```cpp
 CONTROL "Check1",IDC\_CHECK1,"Button",BS\_AUTOCHECKBOX |
 &lt;B&gt;BS\_MULTILINE&lt;/B&gt; | WS\_TABSTOP,21,21,41,10
 CONTROL "Radio1",IDC\_RADIO1,"Button",BS\_AUTORADIOBUTTON |

--- a/globalization/localizability/isolate-localizable-resources.md
+++ b/globalization/localizability/isolate-localizable-resources.md
@@ -51,7 +51,7 @@ Although moving localizable items like strings and icons into resource repositor
 -   The inadvertent translation of resource names that are specific or necessary to your application. (One example includes a command string like "Open" that your code does not recognize anymore because it has been translated to "Ouvrir" in French. Another example is translating the name of a mutex or event that an application is checking for in the source language.)
 -   Also, you should not expect services and system components to always be in English, since they might have been translated for localized versions. For instance, the following code will fail when run on a localized version because all values in bold are translated on localized systems!
 
-```C++
+```cpp
 // user is system, which means cannot log on
 if ( (_tcscmp(lpBuffer,TEXT("SYSTEM")) == 0) ||
  (_tcscmp(lpBuffer,TEXT("LOCAL SERVICE")) == 0) ||
@@ -60,7 +60,7 @@ if ( (_tcscmp(lpBuffer,TEXT("SYSTEM")) == 0) ||
 
 A better way to handle resources that come from localizable platforms is to use application programming interface (API) calls to get the system's localized values. The following example uses *SHGetFolderPath*, which will return the correct localized version of the path from one localized system to another localized system. (For information on the different Shell calls, see the [Shell Programmers Guide](https://msdn.microsoft.com/library/bb776778.aspx).)
 
-```C++
+```cpp
 TCHAR szPath[MAX_PATH];
 SHGetFolderPath(NULL, CSIDL_PERSONAL, NULL, 0, szPath);
 ```

--- a/globalization/localizability/mirroring-in-dotnet-framework.md
+++ b/globalization/localizability/mirroring-in-dotnet-framework.md
@@ -36,8 +36,7 @@ On some occasions, you might want to create a basic form with settings and prope
 
 As its name suggests, the *MessageBox* class represents the message box; the *Show* method of this class displays a message box that can contain text, buttons, and symbols that inform and instruct the user. The *MessageBox* class fully supports RTL reading order and mirroring. The *Show* method of the *MessageBox* class takes constants defined in the *MessageBoxOptions* enumeration as parameters. These constants include *RtlReading* and *RightAlign,* both of which enable the message box to display bidirectional text. The following code illustrates how to display an Arabic message box:
 
-```VB
-[Visual Basic]
+```vb
 MessageBox.Show([put here your Arabic text],
 MessageBoxButtons.OK,
 MessageBoxIcon.Question,

--- a/globalization/localizability/mirroring-in-win32.md
+++ b/globalization/localizability/mirroring-in-win32.md
@@ -26,7 +26,7 @@ By activating the mirroring layout on a per-process basis, all windows that are 
 
 You set the default direction to RTL for a process by calling [SetProcessDefaultLayout](/windows/desktop/api/winuser/nf-winuser-setprocessdefaultlayout) (LAYOUT\_RTL). You can also turn off default mirroring by calling *SetProcessDefaultLayout(0)*. In addition, you can query the current default layout direction as follows:
 
-```C++
+```cpp
 BOOL WINAPI
 GetProcessDefaultLayout(DWORD *pdwDefaultLayout);  
 ```
@@ -45,7 +45,7 @@ A good example of a case where you should prevent the mirroring of child windows
 
 The following code shows how to toggle the layout of a window between RTL and LTR:
 
-```C++
+```cpp
 LONG lExStyles;
 
 // Retrieve the extended style of the window.
@@ -74,7 +74,7 @@ The only way to switch between mirrored and nonmirrored dialog resources at run 
 
 The mirroring technology described up to now applies to all objects in a standard window. These objects, as well as bitmaps and icons in a mirrored window, are all mirrored by default. Obviously, there are some graphics objects, particularly those that include text, that shouldn't be mirrored. Therefore, Microsoft provides several GDI functions in platforms that support mirroring (which, again, includes all versions of Windows 2000 and Windows XP). These functions are shown in the following code:
 
-```C++
+```cpp
 BOOL WINAPI 
  SetLayout(HDC hDc, DWORD dwLayout);
 DWORD WINAPI 
@@ -85,7 +85,7 @@ The device context of a mirrored window is mirrored by default. Nevertheless, yo
 
 Drawing images that may be sensitive to directionality of the output presents a separate problem. To prevent mirroring of bitmaps, call *SetLayout* with the LAYOUT\_BITMAPORIENTATIONPRESERVED bit set in *dwLayout* :
 
-```C++
+```cpp
 SetLayout(hdc, LAYOUT_RTL | LAYOUT_BITMAPORIENTATIONPRESERVED);  
 ```
 
@@ -111,7 +111,7 @@ A tricky situation when enabling mirroring is when you are dealing with property
 
 Perhaps one of the biggest issues when it comes to dealing with mirroring is mapping between screen coordinates and client coordinates, or failing to do so. For example, developers often use code such as the following to position a control in a window:
 
-```C++
+```cpp
 GetWindowRect(hControl, (LPRECT) &rControlRect);
 // Gets coordinates of window in screen coordinates.
 ScreenToClient(hDialog, (LPPOINT) &rControlRect.left);
@@ -121,7 +121,7 @@ ScreenToClient(hDialog, (LPPOINT) &rControlRect.right);
 
 In this code, the left edge of a rectangle becomes the right edge in a mirrored window, and vice versa, causing unintended results. The solution is to replace the *ScreenToClient* calls as shown in the following code:
 
-```C++
+```cpp
 GetWindowRect(hControl, (LPRECT) &rControlRect);
 // Gets coordinates of window in screen coordinates.
 MapWindowPoints (NULL, hDialog, (LPPOINT) &rControlRect, 2);
@@ -131,7 +131,7 @@ This code works because the *MapWindowPoints* API has been modified on platforms
 
 Another common practice that can cause problems in mirrored windows is using offsets in screen coordinates to position objects in a client window, instead of using client coordinates. For example, to position a control in a dialog box, the following code uses the difference in the left edges of the control and the dialog box-in screen coordinates-as the *x* position in client coordinates:
 
-```C++
+```cpp
 RECT rcDialog;
 RECT rcControl;
 HWND hControl = GetDlgItem(hDlg, IDD_CONTROL);
@@ -145,7 +145,7 @@ MoveWindow(hControl, rcControl.left - rcDialog.left, _
 
 This works fine when the dialog window has an LTR layout, and when the mapping mode of the client is MM\_TEXT. The new *x* position in client coordinates corresponds to the difference in the left edges of the control and the dialog box in screen coordinates. In a mirrored dialog box, however, the roles of left and right are reversed. You can remove the assumption from the previous code that near is left and far is right by using [MapWindowPoints](/windows/desktop/api/winuser/nf-winuser-mapwindowpoints) to go into client coordinates, as shown in the following code sample:
 
-```C++
+```cpp
 RECT rcDialog;
 RECT rcControl;
 HWND hControl = GetDlgItem(hDlg, IDD_CONTROL);
@@ -191,7 +191,7 @@ Another solution is to have two different sets of graphics in your resources-one
 
 As a third solution, if you ship a separate set of binaries based on the target localized languages, you can let your localization team mirror those graphics elements using a resource editor. (Most resource editors let you flip images in both *x* and *y* directions nowadays.) A final solution-especially when you don't have direct access to the device context where the graphics will be rendered-is to create a mirrored copy of the resource. You then pass this mirrored copy instead of the original, nonmirrored one. (Again, when the mirrored graphics are rendered on a mirrored device context, they will revert back to their original, intended look.) The following sample code illustrates how to mirror both a bitmap and an icon when each's handle is passed:
 
-```C++
+```cpp
 HBITMAP CreateMirroredBitmap( HBITMAP hbmOrig)
     {
                    HDC hdc, hdcMem1, hdcMem2;
@@ -314,13 +314,13 @@ HBITMAP CreateMirroredBitmap( HBITMAP hbmOrig)
 
 A good way of dealing with graphics is to use image-list controls because of the wide flexibility these controls offer. Image-list controls are also used to manage graphics for other controls like tree-view and list-view controls. However, there is one potential issue that can arise. In the case of direction-sensitive bitmaps, if you are using an image list whose contents will be rendered on a mirrored device context, the image list will not have direct access to the image-list device context. On Windows XP, you can use the image-list flags ILC\_MIRROR and ILC\_PERITEMMIRROR to enable mirroring. If your code needs to run on Windows 2000, Windows 98, or Windows Me with mirroring support, you can use the previous code samples to mirror the direction-sensitive bitmap or icon before adding it to the list. Note, however, that the previous code will allow you to mirror such bitmaps and icons if you are adding these images to the list one by one. If you are adding images to the list more than one at a time, you can tweak the previous code to mirror each element inside the image strip that you are adding to the list. For example, you can modify *CreateMirroredBitmap(),* so that instead of this line:
 
-```C++
+```cpp
 BitBlt(hdcMem2, 0, 0, bm.bmWidth, bm.bmHeight, hdcMem1, 0, 0, SRCCOPY); 
 ```
 
 you can have the following code, where *Width* is the width of each individual image in the image strip that will be added to the image list:
 
-```C++
+```cpp
 int n = bm.bmWidth / Width, i;
 for(i =0; i< n; i++)
  {

--- a/globalization/localizability/win32-formatmessage.md
+++ b/globalization/localizability/win32-formatmessage.md
@@ -8,7 +8,7 @@ ms.date: 06/28/2016
 
 Win32 supports two resource types for storing strings: string tables and message tables. (For more information on message tables, see the section on [Multilingual User Interface (MUI)](https://msdn.microsoft.com/library/windows/desktop/dd374113(v=vs.85).aspx).) String tables make sense for short strings and for strings containing only one replacement parameter; message tables are more convenient for alert and error messages that contain more than one replacement parameter. (Message tables support up to 99 parameters.) The FormatMessage API will substitute variables according to each placemarker's numeric label and not according to the label's position in the string. Localizers can freely change a string's word order and FormatMessage will still return correct results. The file format of the message table is not complicated; you can create message tables with a simple text editor. The following code appears in a message table that contains English and German translations of the same strings. The German translation of IDS\_OTHERIMAGE reverses the positions of the replacement parameters.
 
-```C++
+```cpp
 // Sample.mc
 
      LanguageNames=(German=2:msg00002)
@@ -36,7 +36,7 @@ Win32 supports two resource types for storing strings: string tables and message
 
 The syntax for formatting the first message is as follows:
 
-```C++
+```cpp
   // lpBuf must be large enough to hold the formatted message!
 
         DWORD langID = MAKELANGID(LANG_GERMAN, SUBLANG_GERMAN);
@@ -60,7 +60,7 @@ You can use FormatMessage with string tables as well as with message tables, but
 
 FormatMessage is particularly useful for a number of reasons. In conjunction with the API call GetLastError, you can use it to format error messages returned by the system. An example of this technique is given in the following ReportError routine. FormatMessage also allows you to specify the language of the string you want to retrieve from a message table. LoadString can retrieve only resources associated with the language of the current thread's locale.
 
-```C++
+```cpp
 void ReportError()
  
     {


### PR DESCRIPTION
Testing if #53 is fixed with a new PR

This PR uses the approved language IDs for the code blocks
https://docs.microsoft.com/en-us/contribute/code-in-docs#supported-languages