### PR TITLE
Update windows-keyboard-layouts.md

### DIFF
--- a/globalization/windows-keyboard-layouts.md
+++ b/globalization/windows-keyboard-layouts.md
@@ -7,8 +7,6 @@ ms.date: 01/05/2017
 
 # Windows Keyboard Layouts
 
-![Windows keyboard](https://docs.microsoft.com/globalization/images/Keyboard.png "Windows keyboard")
-
 Choose a keyboard below to view its layouts. To see different keyboard states, move the mouse over state keys such as **Shift**, **Caps** or **AltGr**. You can also lock or unlock those keys by clicking them.
 
 If you use a pop-up blocker, please update your allowable list to include this Web site. Use the browser magnification feature to increase the size of the keyboards.


### PR DESCRIPTION
Remove image of keyboard that shows keyboard hardware set to Android mode. This static keyboard image of a US layout doesn't actually add value at the top of a page of international keyboard layouts.