### PR TITLE
Fixes to surrogate pairs documentation

### DIFF
--- a/globalization/encoding/surrogate-pairs.md
+++ b/globalization/encoding/surrogate-pairs.md
@@ -37,7 +37,10 @@ There are two sets of variants defined by Unicode:
 
 Similar to surrogate pairs, the code point sequence is comprised of a base character followed by the variation selector (U+FE00-U+FE0F and U+E0100-U+E01EF, abbreviated VS1-VS16 and VS17-VS256).
 
-For example, <span lang="ja">葛</span> \(U+845B) may also be represented as 󠄀<span lang="ja">葛&#xe0100;</span> \(U+845B; VS17/U+E0100).
+For example, the character U+845B (“edible bean; surname”) may have a variation selector applied:
+- U+845B: <span lang="ja" style="font-size:2em">葛</span> 
+- 󠄀U+845B with VS17/U+E0100 applied: <span lang="ja" style="font-size:2em">葛&#xe0100;</span> 
+
 You will need a font that has defined this character for it to correctly display.
 
 ## End-User Defined Characters

--- a/globalization/encoding/surrogate-pairs.md
+++ b/globalization/encoding/surrogate-pairs.md
@@ -38,8 +38,8 @@ There are two sets of variants defined by Unicode:
 Similar to surrogate pairs, the code point sequence is comprised of a base character followed by the variation selector (U+FE00-U+FE0F and U+E0100-U+E01EF, abbreviated VS1-VS16 and VS17-VS256).
 
 For example, the character U+845B (“edible bean; surname”) may have a variation selector applied:
-- U+845B: <span lang="ja"><big>葛</big></span> 
-- 󠄀U+845B with VS17/U+E0100 applied: <span lang="ja"><big>葛&#xe0100;</big></span> 
+- U+845B: <span lang="ja">葛</span>, as used in the name of the railway station <span lang="ja">西葛西駅</span> ([<span lang="ja-Latn">Nishi-Kasi</span>](https://en.wikipedia.org/wiki/Nishi-Kasai_Station))
+- 󠄀U+845B with VS17/U+E0100 applied: <span lang="ja">葛&#xe0100;</span>, as used in the name of the city <span lang="ja">葛&#xe0100;城市</span> ([<span lang="ja-Latn">Katsuragi</span>](https://en.wikipedia.org/wiki/Katsuragi,_Nara))
 
 You will need a font that has defined this character for it to correctly display.
 

--- a/globalization/encoding/surrogate-pairs.md
+++ b/globalization/encoding/surrogate-pairs.md
@@ -37,7 +37,7 @@ There are two sets of variants defined by Unicode:
 
 Similar to surrogate pairs, the code point sequence is comprised of a base character followed by the variation selector (U+FE00-U+FE0F and U+E0100-U+E01EF, abbreviated VS1-VS16 and VS17-VS256).
 
-For example, <span lang="ja">葛</span> \(U+845B) may also be represented as 󠄀<span lang="ja">&#xe0100;</span> \(U+845B; VS17/U+E0100).
+For example, <span lang="ja">葛</span> \(U+845B) may also be represented as 󠄀<span lang="ja">葛&#xe0100;</span> \(U+845B; VS17/U+E0100).
 You will need a font that has defined this character for it to correctly display.
 
 ## End-User Defined Characters

--- a/globalization/encoding/surrogate-pairs.md
+++ b/globalization/encoding/surrogate-pairs.md
@@ -27,7 +27,7 @@ The SMP, or Plane 1, contains several historic scripts and several sets of symbo
 
 ## Variation Selection
 
-Although the Unicode standard represents a large number of characters, the forms the glyphs take can vary from font to font and from culture to culture. A simple is example is the difference between "<span style="font-family:sans-serif">a</span>" and "<span style="font-family:serif">a</span>". For these types of difference there is no need to encode a different code point. This difference is mainly stylistic and is easily recognizable as the same character. However, during the process of encoding some characters there may be cases where characters with the same semantic meaning have different representation for contextual, historical, or stylistic reasons. In those cases, Unicode provides the variation selector method to represent these characters.
+Although the Unicode standard represents a large number of characters, the forms the glyphs take can vary from font to font and from culture to culture. A simple example is the difference between "<span style="font-family:sans-serif">a</span>" and "<span style="font-family:serif">a</span>". For these types of difference there is no need to encode a different code point. This difference is mainly stylistic and is easily recognizable as the same character. However, during the process of encoding some characters there may be cases where characters with the same semantic meaning have different representation for contextual, historical, or stylistic reasons. In those cases, Unicode provides the variation selector method to represent these characters.
 
 There are two sets of variants defined by Unicode:
 

--- a/globalization/encoding/surrogate-pairs.md
+++ b/globalization/encoding/surrogate-pairs.md
@@ -38,8 +38,8 @@ There are two sets of variants defined by Unicode:
 Similar to surrogate pairs, the code point sequence is comprised of a base character followed by the variation selector (U+FE00-U+FE0F and U+E0100-U+E01EF, abbreviated VS1-VS16 and VS17-VS256).
 
 For example, the character U+845B (“edible bean; surname”) may have a variation selector applied:
-- U+845B: <span lang="ja" style="font-size:2em">葛</span> 
-- 󠄀U+845B with VS17/U+E0100 applied: <span lang="ja" style="font-size:2em">葛&#xe0100;</span> 
+- U+845B: <span lang="ja"><big>葛</big></span> 
+- 󠄀U+845B with VS17/U+E0100 applied: <span lang="ja"><big>葛&#xe0100;</big></span> 
 
 You will need a font that has defined this character for it to correctly display.
 

--- a/globalization/encoding/surrogate-pairs.md
+++ b/globalization/encoding/surrogate-pairs.md
@@ -38,7 +38,7 @@ There are two sets of variants defined by Unicode:
 Similar to surrogate pairs, the code point sequence is comprised of a base character followed by the variation selector (U+FE00-U+FE0F and U+E0100-U+E01EF, abbreviated VS1-VS16 and VS17-VS256).
 
 For example, the character U+845B (“edible bean; surname”) may have a variation selector applied:
-- U+845B: <span lang="ja">葛</span>, as used in the name of the railway station <span lang="ja">西葛西駅</span> ([<span lang="ja-Latn">Nishi-Kasi</span>](https://en.wikipedia.org/wiki/Nishi-Kasai_Station))
+- U+845B: <span lang="ja">葛</span>, as used in the name of the railway station <span lang="ja">西葛西駅</span> ([<span lang="ja-Latn">Nishi-Kasai</span>](https://en.wikipedia.org/wiki/Nishi-Kasai_Station))
 - 󠄀U+845B with VS17/U+E0100 applied: <span lang="ja">葛&#xe0100;</span>, as used in the name of the city <span lang="ja">葛&#xe0100;城市</span> ([<span lang="ja-Latn">Katsuragi</span>](https://en.wikipedia.org/wiki/Katsuragi,_Nara))
 
 You will need a font that has defined this character for it to correctly display.

--- a/globalization/encoding/surrogate-pairs.md
+++ b/globalization/encoding/surrogate-pairs.md
@@ -27,7 +27,7 @@ The SMP, or Plane 1, contains several historic scripts and several sets of symbo
 
 ## Variation Selection
 
-Although the Unicode standard represents a large number of characters, the forms the glyphs take can vary from font to font and from culture to culture. A simple is example is the difference between "a" and "a". For these types of difference there is no need to encode a different code point. This difference is mainly stylistic and is easily recognizable as the same character. However, during the process of encoding some characters there may be cases where characters with the same semantic meaning have different representation for contextual, historical, or stylistic reasons. In those cases, Unicode provides the variation selector method to represent these characters.
+Although the Unicode standard represents a large number of characters, the forms the glyphs take can vary from font to font and from culture to culture. A simple is example is the difference between "<span style="font-family:sans-serif">a</span>" and "<span style="font-family:serif">a</span>". For these types of difference there is no need to encode a different code point. This difference is mainly stylistic and is easily recognizable as the same character. However, during the process of encoding some characters there may be cases where characters with the same semantic meaning have different representation for contextual, historical, or stylistic reasons. In those cases, Unicode provides the variation selector method to represent these characters.
 
 There are two sets of variants defined by Unicode:
 


### PR DESCRIPTION
The two `a`s here are meant to be (based upon the sentence) presented in different fonts. Here I've chosen the default sans/serif fonts. However, I'm not sure if the `style` attributes will survive through to the HTML, as it depends upon the processing pipeline… (it does not work properly in the GitHub-rendered markdown).

In addition, the character with a variation selector was missing, and I've reformatted that section to make the difference more obvious.